### PR TITLE
Add parameter for S3 Bucket ARNs

### DIFF
--- a/ECSJenkins.yml
+++ b/ECSJenkins.yml
@@ -72,6 +72,10 @@ Parameters:
     Type: Number
     Description: The time in seconds the ELB will keep idle connections active. Increase this if you see intermittent disconnects of slaves
     Default: '180'
+  S3DeploymentBucketArns:
+    Type: List<String>
+    Description: List of S3 bucket ARNs to give access for deployment
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -103,9 +107,15 @@ Metadata:
           - KinesisStackName
           - S3BackupBucketExists
           - S3BackupBucketName
+      - Label:
+          default: 'S3 Deployment Bucket ARNs'
+        Parameters:
+          - S3DeploymentBucketArns
 Conditions:
   CreateS3Bucket: !Equals [!Ref 'S3BackupBucketExists', 'no']
   CreateSubscriptionFilter: !Equals [!Ref 'SetupKinesisSubscriptionFilter', 'yes']
+  CreateS3DeploymentBucketPolicy: !Not [ !Equals [ '', !Join ['', !Ref S3DeploymentBucketArns] ] ]
+
 Resources:
   ELBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -229,6 +239,25 @@ Resources:
             - s3:PutObject
             Effect: Allow
             Resource: !Sub 'arn:aws:s3:::${S3BackupBucketName}/*'
+  EcsTaskRoleS3DeploymentBucketPolicy:
+    Type: AWS::IAM::Policy
+    Condition: CreateS3DeploymentBucketPolicy
+    Properties:
+      Roles: [!Ref EcsTaskRole]
+      PolicyName: S3DeploymentBucketPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Resource: !Ref S3DeploymentBucketArns
+          Action:
+          - s3:ListBucket
+        - Effect: Allow
+          Resource: !Split [',', !Join ['', [!Join ['/*,', !Ref S3DeploymentBucketArns], '/*']]]
+          Action:
+          - s3:GetObject
+          - s3:PutObject
+          - s3:ListMultipartUploadParts
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:

--- a/LocalSlaveRoles.yml
+++ b/LocalSlaveRoles.yml
@@ -9,6 +9,11 @@ Parameters:
   JenkinsArtifactBucket:
     Description: The name of the jenkins artifact bucket (i.e. JARs)
     Type: String
+  S3DeploymentBucketArns:
+    Type: List<String>
+    Description: List of S3 bucket ARNs to give access for deployment
+Conditions:
+  CreateS3DeploymentBucketPolicy: !Not [ !Equals [ '', !Join ['', !Ref S3DeploymentBucketArns] ] ]
 Resources:
   JenkinsSlaveRole:
     Type: AWS::IAM::Role
@@ -64,6 +69,25 @@ Resources:
             Action:
             - s3:ListBucket
             Resource: !Sub 'arn:aws:s3:::${JenkinsArtifactBucket}'
+  JenkinsSlaveRoleS3DeploymentBucketPolicy:
+    Type: AWS::IAM::Policy
+    Condition: CreateS3DeploymentBucketPolicy
+    Properties:
+      Roles: [!Ref JenkinsSlaveRole]
+      PolicyName: S3DeploymentBucketPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Resource: !Ref S3DeploymentBucketArns
+          Action:
+          - s3:ListBucket
+        - Effect: Allow
+          Resource: !Split [',', !Join ['', [!Join ['/*,', !Ref S3DeploymentBucketArns], '/*']]]
+          Action:
+          - s3:GetObject
+          - s3:PutObject
+          - s3:ListMultipartUploadParts
 
 Outputs:
   TaskRoleArn:


### PR DESCRIPTION
This change will add policies to the IAM roles for the tasks so they can access S3 buckets during deployment